### PR TITLE
Missing gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,8 @@ GEM
     minitest (5.8.4)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
+    omniauth (1.3.1)
+    omniauth-facebook (3.0.0)
     pdf-core (0.6.0)
     pg (0.18.4)
     polyamorous (1.3.0)


### PR DESCRIPTION
Added missing gems in Gemfile.lock (for OAuth) — You may want to check the gem versions before merging